### PR TITLE
Fix filename sanitization regex

### DIFF
--- a/pages/api/generate-image.js
+++ b/pages/api/generate-image.js
@@ -8,7 +8,7 @@ function createSafeFilename(prompt) {
     .toLowerCase()
     .replace(/[^a-z0-9]/g, '-')
     .replace(/-+/g, '-')
-    .replace(/^-|-\$/g, '')
+    .replace(/^-|-$/g, '')
     .slice(0, 50);
 }
 


### PR DESCRIPTION
## Summary
- fix `createSafeFilename` to trim trailing hyphens correctly

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425ae85254832ab9ed8c0b67a40bcb