### PR TITLE
Add Jest and tests for createSafeFilename

### DIFF
--- a/__tests__/createSafeFilename.test.js
+++ b/__tests__/createSafeFilename.test.js
@@ -1,0 +1,15 @@
+import { createSafeFilename } from '../pages/api/generate-image.js';
+
+describe('createSafeFilename', () => {
+  test('normalizes to lowercase and hyphenates spaces', () => {
+    expect(createSafeFilename('Hello WORLD')).toBe('hello-world');
+  });
+
+  test('removes illegal characters', () => {
+    expect(createSafeFilename('Some @File* Name!')).toBe('some-file-name');
+  });
+
+  test('trims leading and trailing hyphens', () => {
+    expect(createSafeFilename('-Hello--World-')).toBe('hello-world');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
     "axios": "^1.7.9",
@@ -26,6 +27,10 @@
     "eslint-config-next": "15.1.6",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/pages/api/generate-image.js
+++ b/pages/api/generate-image.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 // Helper function to create a safe filename from prompt
-function createSafeFilename(prompt) {
+export function createSafeFilename(prompt) {
   return prompt
     .toLowerCase()
     .replace(/[^a-z0-9]/g, '-')


### PR DESCRIPTION
## Summary
- add Jest dev dependency and simple test script
- export `createSafeFilename`
- add tests covering normalization, illegal characters, and trailing hyphens

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425f7420a0832a8f147ec5105e341d